### PR TITLE
fix(linux): ffmpeg/ffprobe exist in /usr/bin on linux

### DIFF
--- a/src/animations/wrap.js
+++ b/src/animations/wrap.js
@@ -6,8 +6,23 @@ const Canvas = require('canvas');
 const fs = require('fs');
 const editly = require('editly');
 
-const ffmpegPath = pwd + 'ffmpeg.exe';
-const ffprobePath = pwd + 'ffprobe.exe';
+function getToolPath(tool) {
+	[
+		`${pwd}${tool}.exe`,
+		`${pwd}${tool}`,
+		`/usr/bin/${tool}`,
+		tool,
+	].forEach((path) => {
+		if (fs.existsSync(path)) {
+			return path;
+		}
+	});
+	console.error(`Could not find ${tool}! Please check if you've downloaded it (or just read the README)!`);
+	process.exit(1);
+}
+
+const ffmpegPath = getToolPath('ffmpeg');
+const ffprobePath = getToolPath('ffprobe');
 const audioFilePath = pwd + 'audio.mp3';
 
 const ffmpeg = require('fluent-ffmpeg');


### PR DESCRIPTION
Closes https://github.com/Assassin-1234/discord-wrapped/issues/5 .

On linux you need to use ffmpeg/ffprobe from the system package manager, which most commonly puts it in `/usr/bin/{ffmpeg,ffprobe}`.