### PR TITLE
Fix createRecentGIFs function to make the filename work with discord new expiry params

### DIFF
--- a/backend/src/generator/animations/wrap.ts
+++ b/backend/src/generator/animations/wrap.ts
@@ -261,7 +261,11 @@ export default async (wrappedId: string, progressCallback: (progress: number, in
 		const pagePromises = tenorLinks.map(async (tenorLink) => {
 			tenorLink = tenorLink.src;
 
-			const filename = tenorLink.split('/').pop() + '.gif';
+			let filename = tenorLink.split('/').pop()
+
+			filename = filename.includes('?') ?
+				filename.split('?').shift() :
+				filename + '.gif';
 
 			const tenorBuffer = await fetchTenorGIF(tenorLink);
 			let ext = '';


### PR DESCRIPTION
instead of just adding `.gif` to the filename, it checks if the filename includes `?` (so if it has discord's query params for expiry) and returns the filename without those (it already has the extension so it isn't added

if the filename doesn't include the query params it just adds the `.gif` extension